### PR TITLE
Changed StampedValue to VectorInput

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,20 +163,20 @@ For example, a simple "single integrator" (velocity input) model can be implemen
         def __init__(self, Q: np.ndarray):
             self._Q = Q
 
-        def evaluate(self, x: VectorState, u: StampedValue, dt: float) -> np.ndarray:
+        def evaluate(self, x: VectorState, u: VectorInput, dt: float) -> np.ndarray:
             """
             Returns a state with an updated value according to a process model.
             """
             x.value = x.value + dt * u.value
             return x
 
-        def jacobian(self, x: VectorState, u: StampedValue, dt: float) -> np.ndarray:
+        def jacobian(self, x: VectorState, u: VectorInput, dt: float) -> np.ndarray:
             """
             Jacobian of the process model with respect to the state.
             """
             return np.identity(x.dof)
 
-        def covariance(self, x: VectorState, u: StampedValue, dt: float) -> np.ndarray:
+        def covariance(self, x: VectorState, u: VectorInput, dt: float) -> np.ndarray:
             """
             Returns the covariance of the process model errors.
             """

--- a/examples/ex_random_walk.py
+++ b/examples/ex_random_walk.py
@@ -56,7 +56,7 @@ def main():
         # The data generator will add noise on top of the already random signal if
         # ``input_covariance`` is not zero. So here we remove this.
 
-        u: nav.StampedValue = input_data[k]
+        u: nav.VectorInput = input_data[k]
         u.value = np.zeros(u.value.shape)  # Zero-out the input
 
         # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -1,0 +1,8 @@
+import navlie as nav
+from navlie.lib import VectorState
+
+x0 = nav.lib.VectorState([0,0,0], stamp=0.0)
+
+class BicycleModel(nav.ProcessModel):
+    def evaluate(self, x: VectorState, u: nav.VectorInput, dt: float) -> VectorState:
+        pass

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -1,8 +1,11 @@
 import navlie as nav
 from navlie.lib import VectorState
 
-x0 = nav.lib.VectorState([0,0,0], stamp=0.0)
+x0 = nav.lib.VectorState([0, 0, 0], stamp=0.0)
+
 
 class BicycleModel(nav.ProcessModel):
-    def evaluate(self, x: VectorState, u: nav.VectorInput, dt: float) -> VectorState:
+    def evaluate(
+        self, x: VectorState, u: nav.VectorInput, dt: float
+    ) -> VectorState:
         pass

--- a/navlie/__init__.py
+++ b/navlie/__init__.py
@@ -4,7 +4,6 @@ from .types import (
     MeasurementModel,
     ProcessModel,
     Input,
-    VectorInput,
     StateWithCovariance,
     Dataset,
 )
@@ -40,3 +39,5 @@ from .utils import (
     randvec,
     jacobian,
 )
+
+from .lib import VectorInput  # for backwards compatibility

--- a/navlie/__init__.py
+++ b/navlie/__init__.py
@@ -4,7 +4,7 @@ from .types import (
     MeasurementModel,
     ProcessModel,
     Input,
-    StampedValue,
+    VectorInput,
     StateWithCovariance,
     Dataset,
 )

--- a/navlie/batch/residuals.py
+++ b/navlie/batch/residuals.py
@@ -12,7 +12,7 @@ These residuals are
 
 from abc import ABC, abstractmethod
 from typing import Hashable, List, Tuple
-from navlie.types import State, ProcessModel, StampedValue, Measurement
+from navlie.types import State, ProcessModel, VectorInput, Measurement
 import numpy as np
 
 
@@ -117,7 +117,7 @@ class ProcessResidual(Residual):
         self,
         keys: List[Hashable],
         process_model: ProcessModel,
-        u: StampedValue,
+        u: VectorInput,
     ):
         super().__init__(keys)
         self._process_model = process_model

--- a/navlie/batch/residuals.py
+++ b/navlie/batch/residuals.py
@@ -12,7 +12,7 @@ These residuals are
 
 from abc import ABC, abstractmethod
 from typing import Hashable, List, Tuple
-from navlie.types import State, ProcessModel, VectorInput, Measurement
+from navlie.types import State, ProcessModel, Measurement, Input
 import numpy as np
 
 
@@ -117,7 +117,7 @@ class ProcessResidual(Residual):
         self,
         keys: List[Hashable],
         process_model: ProcessModel,
-        u: VectorInput,
+        u: Input,
     ):
         super().__init__(keys)
         self._process_model = process_model

--- a/navlie/datagen.py
+++ b/navlie/datagen.py
@@ -6,7 +6,7 @@ from navlie.types import (
     ProcessModel,
     MeasurementModel,
     Input,
-    StampedValue,
+    VectorInput,
     Measurement,
 )
 
@@ -182,9 +182,9 @@ class DataGenerator:
             u = self.input_func(times[k], x)
             Q = np.atleast_2d(self.input_covariance(times[k]))
 
-            # If just the raw value, converted to a StampedValue object
+            # If just the raw value, converted to a VectorInput object
             if not hasattr(u, "stamp"):
-                u = StampedValue(
+                u = VectorInput(
                     value=self.input_func(times[k], x),
                     stamp=times[k],
                     covariance=Q,

--- a/navlie/datagen.py
+++ b/navlie/datagen.py
@@ -6,9 +6,9 @@ from navlie.types import (
     ProcessModel,
     MeasurementModel,
     Input,
-    VectorInput,
     Measurement,
 )
+from navlie.lib import VectorInput
 
 
 class DataGenerator:

--- a/navlie/filters.py
+++ b/navlie/filters.py
@@ -670,7 +670,7 @@ class SigmaPointKalmanFilter:
         ----------
         x : StateWithCovariance
             The current state estimate.
-        u: StampedValue
+        u: VectorInput
             Most recent input, to be used to predict the state forward
             if the measurement stamp is larger than the state stamp.
         y : Measurement

--- a/navlie/lib/__init__.py
+++ b/navlie/lib/__init__.py
@@ -8,6 +8,7 @@ from .states import (
     SL3State,
     CompositeState,
     MatrixLieGroupState,
+    VectorInput,
 )
 
 from .imu import IMU, IMUState, IMUKinematics
@@ -19,6 +20,7 @@ from .models import (
     RangeRelativePose,
     SingleIntegrator,
     DoubleIntegrator,
+    DoubleIntegratorWithBias,
     BodyFrameVelocity,
     RelativeBodyFrameVelocity,
     CompositeMeasurementModel,

--- a/navlie/lib/datasets.py
+++ b/navlie/lib/datasets.py
@@ -102,7 +102,7 @@ class SimulatedPoseRangingDataset(nav.Dataset):
     def get_ground_truth(self) -> List[SE3State]:
         return self.gt_data
 
-    def get_input_data(self) -> List[nav.VectorInput]:
+    def get_input_data(self) -> List[nav.Input]:
         return self.input_data
 
     def get_meas_data(self) -> List[nav.Measurement]:

--- a/navlie/lib/datasets.py
+++ b/navlie/lib/datasets.py
@@ -102,7 +102,7 @@ class SimulatedPoseRangingDataset(nav.Dataset):
     def get_ground_truth(self) -> List[SE3State]:
         return self.gt_data
 
-    def get_input_data(self) -> List[nav.StampedValue]:
+    def get_input_data(self) -> List[nav.VectorInput]:
         return self.input_data
 
     def get_meas_data(self) -> List[nav.Measurement]:

--- a/navlie/lib/models.py
+++ b/navlie/lib/models.py
@@ -2,7 +2,7 @@ from navlie.types import (
     Measurement,
     ProcessModel,
     MeasurementModel,
-    StampedValue,
+    VectorInput,
     Input,
 )
 from navlie.lib.states import (
@@ -53,7 +53,7 @@ class SingleIntegrator(ProcessModel):
         self.dim = Q.shape[0]
 
     def evaluate(
-        self, x: VectorState, u: StampedValue, dt: float
+        self, x: VectorState, u: VectorInput, dt: float
     ) -> np.ndarray:
         x = x.copy()
         x.value = x.value + dt * u.value
@@ -90,7 +90,7 @@ class DoubleIntegrator(ProcessModel):
         self.dim = Q.shape[0]
 
     def evaluate(
-        self, x: VectorState, u: StampedValue, dt: float
+        self, x: VectorState, u: VectorInput, dt: float
     ) -> np.ndarray:
         """
         Evaluate discrete-time process model
@@ -161,7 +161,7 @@ class DoubleIntegratorWithBias(DoubleIntegrator):
         self.dim = int(Q.shape[0] / 2)
 
     def evaluate(
-        self, x: VectorState, u: StampedValue, dt: float
+        self, x: VectorState, u: VectorInput, dt: float
     ) -> VectorState:
         """
         Evaluate discrete-time process model
@@ -254,14 +254,14 @@ class BodyFrameVelocity(ProcessModel):
         self._Q = Q
 
     def evaluate(
-        self, x: MatrixLieGroupState, u: StampedValue, dt: float
+        self, x: MatrixLieGroupState, u: VectorInput, dt: float
     ) -> MatrixLieGroupState:
         x = x.copy()
         x.value = x.value @ x.group.Exp(u.value * dt)
         return x
 
     def jacobian(
-        self, x: MatrixLieGroupState, u: StampedValue, dt: float
+        self, x: MatrixLieGroupState, u: VectorInput, dt: float
     ) -> np.ndarray:
         if x.direction == "right":
             return x.group.adjoint(x.group.Exp(-u.value * dt))
@@ -269,7 +269,7 @@ class BodyFrameVelocity(ProcessModel):
             return np.identity(x.dof)
 
     def covariance(
-        self, x: MatrixLieGroupState, u: StampedValue, dt: float
+        self, x: MatrixLieGroupState, u: VectorInput, dt: float
     ) -> np.ndarray:
         if x.direction == "right":
             L = dt * x.group.left_jacobian(-u.value * dt)
@@ -286,7 +286,7 @@ class RelativeBodyFrameVelocity(ProcessModel):
         self._Q2 = Q2
 
     def evaluate(
-        self, x: MatrixLieGroupState, u: StampedValue, dt: float
+        self, x: MatrixLieGroupState, u: VectorInput, dt: float
     ) -> MatrixLieGroupState:
         x = x.copy()
         u = u.value.reshape((2, round(u.value.size / 2)))
@@ -294,7 +294,7 @@ class RelativeBodyFrameVelocity(ProcessModel):
         return x
 
     def jacobian(
-        self, x: MatrixLieGroupState, u: StampedValue, dt: float
+        self, x: MatrixLieGroupState, u: VectorInput, dt: float
     ) -> np.ndarray:
         u = u.value.reshape((2, round(u.value.size / 2)))
         if x.direction == "right":
@@ -305,7 +305,7 @@ class RelativeBodyFrameVelocity(ProcessModel):
             )
 
     def covariance(
-        self, x: MatrixLieGroupState, u: StampedValue, dt: float
+        self, x: MatrixLieGroupState, u: VectorInput, dt: float
     ) -> np.ndarray:
         u = u.value.reshape((2, round(u.value.size / 2)))
         u1 = u[0]

--- a/navlie/lib/models.py
+++ b/navlie/lib/models.py
@@ -2,13 +2,13 @@ from navlie.types import (
     Measurement,
     ProcessModel,
     MeasurementModel,
-    VectorInput,
     Input,
 )
 from navlie.lib.states import (
     CompositeState,
     MatrixLieGroupState,
     VectorState,
+    VectorInput,
 )
 from pymlg import SO2, SO3
 import numpy as np
@@ -52,9 +52,7 @@ class SingleIntegrator(ProcessModel):
         self._Q = Q
         self.dim = Q.shape[0]
 
-    def evaluate(
-        self, x: VectorState, u: VectorInput, dt: float
-    ) -> np.ndarray:
+    def evaluate(self, x: VectorState, u: VectorInput, dt: float) -> np.ndarray:
         x = x.copy()
         x.value = x.value + dt * u.value
         return x
@@ -89,9 +87,7 @@ class DoubleIntegrator(ProcessModel):
         self._Q = Q
         self.dim = Q.shape[0]
 
-    def evaluate(
-        self, x: VectorState, u: VectorInput, dt: float
-    ) -> np.ndarray:
+    def evaluate(self, x: VectorState, u: VectorInput, dt: float) -> np.ndarray:
         """
         Evaluate discrete-time process model
         """

--- a/navlie/lib/preintegration.py
+++ b/navlie/lib/preintegration.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Any, Callable, Tuple
-from navlie.types import StampedValue, ProcessModel, Input
+from navlie.types import VectorInput, ProcessModel, Input
 from navlie.lib.imu import (
     IMU,
     IMUState,
@@ -375,7 +375,7 @@ class BodyVelocityIncrement(RelativeMotionIncrement):
         self.bias = bias
         self.new_bias = bias
 
-    def increment(self, u: StampedValue, dt):
+    def increment(self, u: VectorInput, dt):
         """
         In-place updating the RMI given an input measurement `u` and a duration `dt`
         over which to preintegrate.
@@ -657,8 +657,8 @@ class LinearIncrement(RelativeMotionIncrement):
     def __init__(
         self,
         input_covariance: np.ndarray,
-        state_matrix: Callable[[StampedValue, float], np.ndarray],
-        input_matrix: Callable[[StampedValue, float], np.ndarray],
+        state_matrix: Callable[[VectorInput, float], np.ndarray],
+        input_matrix: Callable[[VectorInput, float], np.ndarray],
         dof: int,
         bias: np.ndarray = None,
         state_id: Any = None,
@@ -670,10 +670,10 @@ class LinearIncrement(RelativeMotionIncrement):
         input_covariance : numpy.ndarray
             Covariance associated with the input. If a bias is also supplied,
             then this should also contain the covariance of the bias random walk.
-        state_matrix : Callable[[StampedValue, float], numpy.ndarray]
+        state_matrix : Callable[[VectorInput, float], numpy.ndarray]
             The state transition matrix, supplied as a function of the input
             and time interval `dt`.
-        input_matrix : Callable[[StampedValue, float], numpy.ndarray]
+        input_matrix : Callable[[VectorInput, float], numpy.ndarray]
             The input matrix, supplied as a function of the input and time
             interval `dt`.
         dof : int
@@ -715,7 +715,7 @@ class LinearIncrement(RelativeMotionIncrement):
         self.new_bias = self.original_bias
         self.stamps = [None, None]
 
-    def increment(self, u: StampedValue, dt: float):
+    def increment(self, u: VectorInput, dt: float):
         u = u.copy()
 
         if self.stamps[0] is None:

--- a/navlie/lib/preintegration.py
+++ b/navlie/lib/preintegration.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Any, Callable, Tuple
-from navlie.types import VectorInput, ProcessModel, Input
+from navlie.types import ProcessModel, Input
 from navlie.lib.imu import (
     IMU,
     IMUState,
@@ -10,7 +10,7 @@ from navlie.lib.imu import (
     L_matrix,
     G_matrix,
 )
-from navlie.lib.states import MatrixLieGroupState, VectorState
+from navlie.lib.states import MatrixLieGroupState, VectorState, VectorInput
 import numpy as np
 from pymlg import SO3, SE3, SE2, SE23, MatrixLieGroup
 

--- a/navlie/types.py
+++ b/navlie/types.py
@@ -45,7 +45,7 @@ class Input(ABC):
         pass
 
 
-class StampedValue(Input):
+class VectorInput(Input):
     """
     Generic data container for timestamped information.
     """
@@ -72,7 +72,7 @@ class StampedValue(Input):
             covariance=covariance,
         )
 
-    def plus(self, w: np.ndarray) -> "StampedValue":
+    def plus(self, w: np.ndarray) -> "VectorInput":
         """
         Generic addition operation to modify the internal value.
 
@@ -87,11 +87,11 @@ class StampedValue(Input):
         new.value = new.value.reshape(og_shape)
         return new
 
-    def copy(self) -> "StampedValue":
+    def copy(self) -> "VectorInput":
         """
         Returns a copy of the instance with fully seperate memory.
         """
-        return StampedValue(
+        return VectorInput(
             self.value.copy(), self.stamp, self.state_id, self.covariance
         )
 
@@ -104,6 +104,8 @@ class StampedValue(Input):
         ]
         return "\n".join(s)
 
+class StampedValue(VectorInput):
+    pass # For backwards compatibility
 
 class State(ABC):
     """

--- a/navlie/types.py
+++ b/navlie/types.py
@@ -45,68 +45,6 @@ class Input(ABC):
         pass
 
 
-class VectorInput(Input):
-    """
-    Generic data container for timestamped information.
-    """
-
-    __slots__ = ["value"]
-
-    def __init__(
-        self,
-        value: np.ndarray,
-        stamp: float = None,
-        state_id: Any = None,
-        covariance=None,
-    ):
-        if not isinstance(value, np.ndarray):
-            value = np.array(value, dtype=np.float64)
-
-        #:numpy.ndarray:  Variable containing the data values
-        self.value = value
-
-        super().__init__(
-            dof=value.size,
-            stamp=stamp,
-            state_id=state_id,
-            covariance=covariance,
-        )
-
-    def plus(self, w: np.ndarray) -> "VectorInput":
-        """
-        Generic addition operation to modify the internal value.
-
-        Parameters
-        ----------
-        w : np.ndarray
-            to be added to the instance's .value
-        """
-        new = self.copy()
-        og_shape = new.value.shape
-        new.value = new.value.ravel() + w.ravel()
-        new.value = new.value.reshape(og_shape)
-        return new
-
-    def copy(self) -> "VectorInput":
-        """
-        Returns a copy of the instance with fully seperate memory.
-        """
-        return VectorInput(
-            self.value.copy(), self.stamp, self.state_id, self.covariance
-        )
-
-    def __repr__(self):
-        value_str = str(self.value).split("\n")
-        value_str = "\n".join(["    " + s for s in value_str])
-        s = [
-            f"{self.__class__.__name__}(stamp={self.stamp}, state_id={self.state_id})",
-            f"{value_str}",
-        ]
-        return "\n".join(s)
-
-class StampedValue(VectorInput):
-    pass # For backwards compatibility
-
 class State(ABC):
     """
     An abstract state :math:`\mathbf{x}` is an object containing the following attributes:

--- a/tests/unit/test_batch_residuals.py
+++ b/tests/unit/test_batch_residuals.py
@@ -1,10 +1,11 @@
 """Tests for the process and measurement residuals found in batch.py"""
 
-from navlie.types import VectorInput, Measurement
-from navlie.lib.models import (
+from navlie.types import Measurement
+from navlie.lib import (
     SingleIntegrator,
     BodyFrameVelocity,
     GlobalPosition,
+    VectorInput,
 )
 from navlie.batch.estimator import (
     PriorResidual,

--- a/tests/unit/test_batch_residuals.py
+++ b/tests/unit/test_batch_residuals.py
@@ -1,6 +1,6 @@
 """Tests for the process and measurement residuals found in batch.py"""
 
-from navlie.types import StampedValue, Measurement
+from navlie.types import VectorInput, Measurement
 from navlie.lib.models import (
     SingleIntegrator,
     BodyFrameVelocity,
@@ -40,7 +40,7 @@ def test_prior_residual_se3():
 
 def test_process_residual_vector_state():
     # Test proccess error for vector state
-    u = StampedValue([1, 2, 3], 0.0)
+    u = VectorInput([1, 2, 3], 0.0)
     x1 = VectorState([4, 5, 6], stamp=0.0)
     dt = 0.1
     model = SingleIntegrator(np.identity(3))
@@ -53,7 +53,7 @@ def test_process_residual_vector_state():
 
 def test_process_residual_se3_state():
     x1 = SE3State(SE3.random(), direction="left", stamp=0.0)
-    u = StampedValue(np.array([1, 2, 3, 4, 5, 6]), stamp=0.0)
+    u = VectorInput(np.array([1, 2, 3, 4, 5, 6]), stamp=0.0)
     dt = 0.1
     model = BodyFrameVelocity(np.identity(6))
     x2 = model.evaluate(x1.copy(), u, dt)

--- a/tests/unit/test_body_velocity.py
+++ b/tests/unit/test_body_velocity.py
@@ -1,13 +1,12 @@
-from navlie.lib.states import SE2State, SE3State, SE23State
-from navlie.lib.models import (
+from navlie.lib import SE2State, SE3State
+from navlie.lib import (
     BodyFrameVelocity,
-    RangePoseToAnchor,
     RelativeBodyFrameVelocity,
+    VectorInput,
 )
-from pymlg import SO2, SO3, SE3, SE2, SE3, SE23
+from pymlg import SE3, SE2, SE3
 import numpy as np
 import pytest
-from navlie.types import VectorInput
 
 
 @pytest.mark.parametrize("direction", ["left", "right"])

--- a/tests/unit/test_body_velocity.py
+++ b/tests/unit/test_body_velocity.py
@@ -7,7 +7,7 @@ from navlie.lib.models import (
 from pymlg import SO2, SO3, SE3, SE2, SE3, SE23
 import numpy as np
 import pytest
-from navlie.types import StampedValue
+from navlie.types import VectorInput
 
 
 @pytest.mark.parametrize("direction", ["left", "right"])
@@ -16,7 +16,7 @@ def test_body_velocity_se3(direction):
         SE3.random(),
         direction=direction,
     )
-    u = StampedValue(np.array([1, 2, 3, 4, 5, 6]))
+    u = VectorInput(np.array([1, 2, 3, 4, 5, 6]))
     dt = 0.1
     Q = np.identity(6)
     process_model = BodyFrameVelocity(Q)
@@ -31,7 +31,7 @@ def test_body_velocity_se2(direction):
         SE2.random(),
         direction=direction,
     )
-    u = StampedValue(np.array([1, 2, 3]))
+    u = VectorInput(np.array([1, 2, 3]))
     dt = 0.1
     Q = np.identity(3)
     process_model = BodyFrameVelocity(Q)
@@ -47,7 +47,7 @@ def test_body_velocity_se3_left(direction):
         SE3.random(),
         direction=direction,
     )
-    u = StampedValue(np.array([1, 2, 3, 4, 5, 6]))
+    u = VectorInput(np.array([1, 2, 3, 4, 5, 6]))
     dt = 0.1
     Q = np.identity(6)
     process_model = BodyFrameVelocity(Q)
@@ -62,7 +62,7 @@ def test_body_velocity_se2_left(direction):
         SE2.random(),
         direction=direction,
     )
-    u = StampedValue(np.array([1, 2, 3]))
+    u = VectorInput(np.array([1, 2, 3]))
     dt = 0.1
     Q = np.identity(3)
     process_model = BodyFrameVelocity(Q)
@@ -77,7 +77,7 @@ def test_relative_body_velocity_se2():
         SE2.random(),
         direction="right",
     )
-    u = StampedValue(np.array([1, 2, 3, 4, 5, 6]))
+    u = VectorInput(np.array([1, 2, 3, 4, 5, 6]))
     dt = 0.1
     Q = np.identity(3)
     process_model = RelativeBodyFrameVelocity(Q, Q)
@@ -92,7 +92,7 @@ def test_relative_body_velocity_se3():
         SE3.random(),
         direction="right",
     )
-    u = StampedValue(np.array([i for i in range(12)]))
+    u = VectorInput(np.array([i for i in range(12)]))
     dt = 0.1
     Q = np.identity(6)
     process_model = RelativeBodyFrameVelocity(Q, Q)
@@ -111,7 +111,7 @@ def test_relative_body_velocity_equivalence():
         T_12,
         direction="right",
     )
-    u = StampedValue(np.array([i for i in range(12)]).reshape((-1, 6)))
+    u = VectorInput(np.array([i for i in range(12)]).reshape((-1, 6)))
     dt = 0.1
     Q = np.identity(6)
     process_model = RelativeBodyFrameVelocity(Q, Q)

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -1,5 +1,5 @@
 from navlie.lib.states import SE2State, CompositeState, VectorState
-from navlie.types import StampedValue
+from navlie.types import VectorInput
 from navlie.lib.models import (
     BodyFrameVelocity,
     CompositeProcessModel,
@@ -22,8 +22,8 @@ def test_composite_process_model():
     )
     u = CompositeInput(
         [
-            StampedValue(np.array([0.3, 1, 0]), 1),
-            StampedValue(np.array([-0.3, 2, 0]), 1),
+            VectorInput(np.array([0.3, 1, 0]), 1),
+            VectorInput(np.array([-0.3, 2, 0]), 1),
         ]
     )
     dt = 1
@@ -47,8 +47,8 @@ def test_shared_input():
     )
     u = CompositeInput(
         [
-            StampedValue(np.array([0.3, 1, 0]), 1),
-            StampedValue(np.array([0.3, 1, 0]), 1),
+            VectorInput(np.array([0.3, 1, 0]), 1),
+            VectorInput(np.array([0.3, 1, 0]), 1),
         ]
     )
     dt = 1

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -1,10 +1,12 @@
-from navlie.lib.states import SE2State, CompositeState, VectorState
-from navlie.types import VectorInput
-from navlie.lib.models import (
+from navlie.lib import (
     BodyFrameVelocity,
     CompositeProcessModel,
     RangeRelativePose,
     CompositeInput,
+    VectorInput,
+    SE2State,
+    VectorState,
+    CompositeState,
 )
 from pymlg import SE2
 import numpy as np

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -14,7 +14,7 @@ def test_iterated_ekf():
     range_model = nav.lib.RangePointToAnchor([0, 4], R)
     process_model = nav.lib.SingleIntegrator(Q)
     y = nav.generate_measurement(x, range_model)
-    u = nav.StampedValue([1, 2], stamp=0.0)
+    u = nav.VectorInput([1, 2], stamp=0.0)
 
     x = nav.StateWithCovariance(x, P)
     kf = nav.IteratedKalmanFilter(process_model)
@@ -34,7 +34,7 @@ def test_iterated_ekf_no_line_search():
     range_model = nav.lib.RangePointToAnchor([0, 4], R)
     process_model = nav.lib.SingleIntegrator(Q)
     y = nav.generate_measurement(x, range_model)
-    u = nav.StampedValue([1, 2], stamp=0.0)
+    u = nav.VectorInput([1, 2], stamp=0.0)
 
     x = nav.StateWithCovariance(x, P)
     kf = nav.IteratedKalmanFilter(process_model, line_search=False)
@@ -56,7 +56,7 @@ def test_iterated_ekf_equivalence():
     range_model = nav.lib.RangePointToAnchor([0, 4], R)
     process_model = nav.lib.SingleIntegrator(Q)
     y = nav.generate_measurement(x, range_model)
-    u = nav.StampedValue([1, 2], stamp=0.0)
+    u = nav.VectorInput([1, 2], stamp=0.0)
 
     x = nav.StateWithCovariance(x, P)
     kf = nav.IteratedKalmanFilter(process_model, max_iters=1, line_search=False)

--- a/tests/unit/test_preintegration.py
+++ b/tests/unit/test_preintegration.py
@@ -16,7 +16,7 @@ from navlie.filters import ExtendedKalmanFilter
 from navlie.lib.states import SE3State, VectorState
 import numpy as np
 from pymlg import SE23, SE2, SE3, SO3
-from navlie.types import StampedValue, StateWithCovariance
+from navlie.types import VectorInput, StateWithCovariance
 import pytest
 
 np.set_printoptions(precision=5, suppress=True, linewidth=200)
@@ -100,7 +100,7 @@ def test_odometry_preintegration_se3_equivalence(direction):
 
     model = BodyFrameVelocity(Q)
     dt = 0.01
-    u = StampedValue([1, 2, 3, 4, 5, 6], 0)
+    u = VectorInput([1, 2, 3, 4, 5, 6], 0)
     x = SE3State(SE3.random(), stamp=0.0, direction=direction)
     P0 = np.identity(6)
     ekf = ExtendedKalmanFilter(model)
@@ -132,7 +132,7 @@ def test_preintegrated_process_jacobian_body_velocity(direction):
     Q = np.identity(6)
     bias = [0, 0, 0, 0, 0, 0]
     dt = 0.01
-    u = StampedValue([1, 2, 3, 4, 5, 6], 0)
+    u = VectorInput([1, 2, 3, 4, 5, 6], 0)
     x = SE3State(SE3.random(), stamp=0.0, direction=direction)
     rmi = BodyVelocityIncrement(x.group, Q, bias=bias)
     preint_model = PreintegratedBodyVelocity()
@@ -216,7 +216,7 @@ def test_double_integrator_preintegration():
     Q = np.identity(2)
 
     dt = 0.01
-    u = StampedValue([1, 2], 0)
+    u = VectorInput([1, 2], 0)
     x = VectorState([0, 0, 0, 0], stamp=0.0)
     P0 = np.identity(4)
 
@@ -257,7 +257,7 @@ def test_double_integrator_preintegration_with_bias():
     bias = [0, 2]
 
     dt = 0.01
-    u = StampedValue([1, 2], 0)
+    u = VectorInput([1, 2], 0)
     x = VectorState([0, 0, 0, 0] + bias, stamp=0.0)
     P0 = np.identity(6)
 
@@ -300,8 +300,8 @@ def test_double_integrator_bias_equivalence():
     bias = [0, 2]
 
     dt = 0.01
-    u = StampedValue([1, 2], 0)
-    u2 = StampedValue([1, 2, 0, 0], 0)
+    u = VectorInput([1, 2], 0)
+    u2 = VectorInput([1, 2, 0, 0], 0)
     x = VectorState([0, 0, 0, 0] + bias, stamp=0.0)
     P0 = np.identity(6)
 

--- a/tests/unit/test_preintegration.py
+++ b/tests/unit/test_preintegration.py
@@ -1,22 +1,24 @@
-from navlie.lib.imu import IMU, IMUKinematics, IMUState
-from navlie.lib.preintegration import (
+from navlie.lib import (
     BodyVelocityIncrement,
     IMUIncrement,
     PreintegratedBodyVelocity,
     PreintegratedIMUKinematics,
     LinearIncrement,
     PreintegratedLinearModel,
-)
-from navlie.lib.models import (
+    IMU,
+    IMUKinematics,
+    IMUState,
     BodyFrameVelocity,
     DoubleIntegrator,
-    DoubleIntegratorWithBias,
+    VectorInput,
+    SE3State,
+    VectorState,
 )
+from navlie.lib.models import DoubleIntegratorWithBias
 from navlie.filters import ExtendedKalmanFilter
-from navlie.lib.states import SE3State, VectorState
 import numpy as np
-from pymlg import SE23, SE2, SE3, SO3
-from navlie.types import VectorInput, StateWithCovariance
+from pymlg import SE23, SE3
+from navlie import StateWithCovariance, ExtendedKalmanFilter
 import pytest
 
 np.set_printoptions(precision=5, suppress=True, linewidth=200)

--- a/tests/unit/test_process_models.py
+++ b/tests/unit/test_process_models.py
@@ -4,12 +4,12 @@ from navlie.lib.models import (
     DoubleIntegratorWithBias,
 )
 from navlie.lib.states import VectorState
-from navlie.types import StampedValue
+from navlie.types import VectorInput
 import numpy as np
 
 
 def test_single_integrator_jacobian():
-    u = StampedValue([1, 2, 3], 0)
+    u = VectorInput([1, 2, 3], 0)
     x = VectorState([4, 5, 6])
     model = SingleIntegrator(np.identity(3))
     jac = model.jacobian(x, u, 0.1)
@@ -18,7 +18,7 @@ def test_single_integrator_jacobian():
 
 
 def test_single_integrator_covariance():
-    u = StampedValue([1, 2, 3], 0)
+    u = VectorInput([1, 2, 3], 0)
     x = VectorState([4, 5, 6])
     model = SingleIntegrator(np.identity(3))
     cov = model.covariance(x, u, 0.1)
@@ -28,7 +28,7 @@ def test_single_integrator_covariance():
 
 
 def test_double_integrator_jacobian():
-    u = StampedValue([1, 2, 3], 0)
+    u = VectorInput([1, 2, 3], 0)
     x = VectorState([1, 2, 3, 4, 5, 6])
     model = DoubleIntegrator(np.identity(3))
     jac = model.jacobian(x, u, 0.1)
@@ -37,7 +37,7 @@ def test_double_integrator_jacobian():
 
 
 def test_double_integrator_covariance():
-    u = StampedValue([1, 2, 3], 0)
+    u = VectorInput([1, 2, 3], 0)
     x = VectorState([1, 2, 3, 4, 5, 6])
     model = DoubleIntegrator(np.identity(3))
     cov = model.covariance(x, u, 0.1)
@@ -47,7 +47,7 @@ def test_double_integrator_covariance():
 
 
 def test_double_integrator_with_bias_jacobian():
-    u = StampedValue([1, 2, 3], 0)
+    u = VectorInput([1, 2, 3], 0)
     x = VectorState([1, 2, 3, 4, 5, 6, 7, 8, 9])
     model = DoubleIntegratorWithBias(0.2 * np.identity(6))
     jac = model.jacobian(x, u, 0.1)
@@ -56,7 +56,7 @@ def test_double_integrator_with_bias_jacobian():
 
 
 def test_double_integrator_with_bias_covariance():
-    u = StampedValue([1, 2, 3, 4, 5, 6], 0)
+    u = VectorInput([1, 2, 3, 4, 5, 6], 0)
     x = VectorState([1, 2, 3, 4, 5, 6, 7, 8, 9])
     Q = 0.2 * np.identity(6)
     model = DoubleIntegratorWithBias(Q)

--- a/tests/unit/test_process_models.py
+++ b/tests/unit/test_process_models.py
@@ -1,10 +1,11 @@
-from navlie.lib.models import (
+from navlie.lib import (
     SingleIntegrator,
     DoubleIntegrator,
     DoubleIntegratorWithBias,
+    VectorInput,
+    VectorState,
 )
-from navlie.lib.states import VectorState
-from navlie.types import VectorInput
+from navlie.lib import VectorState, VectorInput
 import numpy as np
 
 

--- a/tests/unit/test_spkf.py
+++ b/tests/unit/test_spkf.py
@@ -36,12 +36,12 @@ def test_generate_sigmapoints():
 
     x_propagated = [x.plus(sp) for sp in sps.T]
 
-    assert np.allclose(mean_state(x_propagated, w).value, x.value)
+    assert np.allclose(mean_state(x_propagated, w).value, x.value, atol=1e-5)
     sps, w = generate_sigmapoints(x.dof, "gh")
 
     x_propagated = [x.plus(sp) for sp in sps.T]
 
-    assert np.allclose(mean_state(x_propagated, w).value, x.value)
+    assert np.allclose(mean_state(x_propagated, w).value, x.value, atol=1e-5)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_states.py
+++ b/tests/unit/test_states.py
@@ -49,7 +49,7 @@ def test_plus_jacobian(s: str):
     dx = np.random.randn(x.dof)
     jac = x.plus_jacobian(dx)
     jac_test = x.plus_jacobian_fd(dx)
-    assert np.allclose(jac, jac_test, atol=1e-5)
+    assert np.allclose(jac, jac_test, atol=1e-4)
 
 
 @pytest.mark.parametrize(
@@ -101,3 +101,7 @@ def test_so3_ros():
     assert x.stamp == x2.stamp
     assert x.state_id == x2.state_id
     assert x.state_id == x_ros.header.frame_id
+
+
+if __name__ == "__main__":
+    test_minus_jacobian("sl3")


### PR DESCRIPTION
Still maintained old class for backwards compatibility, so this wont be a breaking change.

StampedValue was exclusively used for process model inputs. From a consistency standpoint, it makes more sense to follow a format similar to `VectorState` 