### PR TITLE
Minor fix in np.linalg.solve dimensions

### DIFF
--- a/navlie/utils/common.py
+++ b/navlie/utils/common.py
@@ -1212,8 +1212,14 @@ class GaussianResultList:
             out.nees = out.error**2 / out.covariance.flatten()
             out.dof = np.ones_like(out.stamp)
         else:
+            n_times = out.covariance.shape[0]
+            n_error = out.covariance.shape[1]
             out.nees = np.sum(
-                out.error * np.linalg.solve(out.covariance, out.error), axis=1
+                out.error
+                * np.linalg.solve(
+                    out.covariance, out.error.reshape((n_times, n_error, 1))
+                ).reshape((n_times, n_error)),
+                axis=1,
             )
             out.dof = out.error.shape[1] * np.ones_like(out.stamp)
 


### PR DESCRIPTION
Update compatibility with new broadcasting rules in Numpy 2.0.0 np.linalg.solve. See https://github.com/numpy/numpy/pull/25914 for broadcasting ambiguity in previous versions of Numpy